### PR TITLE
Improved exception handling on Android

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/Errors.java
+++ b/android/src/main/java/com/gettipsi/stripe/Errors.java
@@ -1,6 +1,6 @@
 package com.gettipsi.stripe;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.gettipsi.stripe.util.ArgCheck;
@@ -40,7 +40,7 @@ public final class Errors {
     String errorCode = exceptionClassToErrorCode.get(exceptionClass);
 
     if (errorCode == null) {
-      throw exception
+      throw new UnknownErrorCodeException("Unknown error code", exception);
     }
 
     return errorCode;
@@ -53,5 +53,10 @@ public final class Errors {
   static String getDescription(@NonNull ReadableMap errorCodes, @NonNull String errorKey) {
     return errorCodes.getMap(errorKey).getString("description");
   }
+}
 
+class UnknownErrorCodeException extends RuntimeException {
+  public UnknownErrorCodeException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/android/src/main/java/com/gettipsi/stripe/Errors.java
+++ b/android/src/main/java/com/gettipsi/stripe/Errors.java
@@ -8,13 +8,15 @@ import com.gettipsi.stripe.util.ArgCheck;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.stripe.android.exception.*;
+
 /**
  * Created by ngoriachev on 30/07/2018.
  */
 
 public final class Errors {
 
-  private static final Map<String, String> exceptionNameToErrorCode = new HashMap<>();
+  private static final Map<Class, String> exceptionClassToErrorCode = new HashMap<>();
 
   public static final String CANCELLED = "cancelled";
   public static final String FAILED = "failed";
@@ -22,25 +24,24 @@ public final class Errors {
   public static final String UNEXPECTED = "unexpected";
 
   static {
-    exceptionNameToErrorCode.put("APIConnectionException", "apiConnection");
-    exceptionNameToErrorCode.put("StripeException", "stripe");
-    exceptionNameToErrorCode.put("CardException", "card");
-    exceptionNameToErrorCode.put("AuthenticationException", "authentication");
-    exceptionNameToErrorCode.put("PermissionException", "permission");
-    exceptionNameToErrorCode.put("InvalidRequestException", "invalidRequest");
-    exceptionNameToErrorCode.put("RateLimitException", "rateLimit");
-    exceptionNameToErrorCode.put("APIException", "api");
+    exceptionClassToErrorCode.put(APIConnectionException.class, "apiConnection");
+    exceptionClassToErrorCode.put(StripeException.class, "stripe");
+    exceptionClassToErrorCode.put(CardException.class, "card");
+    exceptionClassToErrorCode.put(AuthenticationException.class, "authentication");
+    exceptionClassToErrorCode.put(PermissionException.class, "permission");
+    exceptionClassToErrorCode.put(InvalidRequestException.class, "invalidRequest");
+    exceptionClassToErrorCode.put(RateLimitException.class, "rateLimit");
+    exceptionClassToErrorCode.put(APIException.class, "api");
   }
 
   public static String toErrorCode(@NonNull Exception exception) {
     ArgCheck.nonNull(exception);
-    String simpleName = exception.getClass().getSimpleName();
-    String errorCode = exceptionNameToErrorCode.get(simpleName);
+    Class exceptionClass = exception.getClass();
+    String errorCode = exceptionClassToErrorCode.get(exceptionClass);
 
     if (errorCode == null) {
-      errorCode = simpleName;
+      throw exception
     }
-//    ArgCheck.nonNull(errorCode, simpleName);
 
     return errorCode;
   }


### PR DESCRIPTION
## Proposed changes
Instead of matching exception class simple names to an error codes I've updated the code to match the exception class to the error codes.

The issue we discovered was that ProGuard would obfuscate the class simple names. This would cause the error code lookup table to always miss and throw a NullPointerException.

An alternative solution would have been to adjust our ProGuard rules to prevent obfuscating. While this would fix the issue this wouldn't help anybody else running into this.

Additionally, I didn't like that when the lookup table missed a non-descript NullPointerException would be thrown. I've updated that to simply rethrow the error so that crash logs will at least have the root cause error rather than the non-descript NullPointerException.

## Types of changes
* [x]  Bugfix (a non-breaking change which fixes an issue)
* [ ]  New feature (a non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
* [x]  I have added tests that prove my fix is useful or that my feature works
* [x]  I have added necessary documentation (if appropriate)
* [x]  I know that my PR will be merged only if it has tests and they pass

